### PR TITLE
[#240][FRONT][장바구니/메인페이지] - 메인페이지 작업 및 비회원쿠키 생성 위치 수정

### DIFF
--- a/frontend-server/src/main/java/shop/bluebooktle/frontend/config/WebConfig.java
+++ b/frontend-server/src/main/java/shop/bluebooktle/frontend/config/WebConfig.java
@@ -5,6 +5,9 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.filter.RequestContextFilter;
 
+import shop.bluebooktle.frontend.config.filter.GuestIdFilter;
+import shop.bluebooktle.frontend.util.CookieTokenUtil;
+
 @Configuration
 public class WebConfig {
 
@@ -14,5 +17,14 @@ public class WebConfig {
 		registrationBean.setFilter(new RequestContextFilter());
 
 		return registrationBean;
+	}
+
+	@Bean
+	public FilterRegistrationBean<GuestIdFilter> guestIdFilter(CookieTokenUtil cookieTokenUtil) {
+		FilterRegistrationBean<GuestIdFilter> registration = new FilterRegistrationBean<>();
+		registration.setFilter(new GuestIdFilter(cookieTokenUtil));
+		registration.addUrlPatterns("/*");
+		registration.setOrder(0);
+		return registration;
 	}
 }

--- a/frontend-server/src/main/java/shop/bluebooktle/frontend/config/filter/GuestIdFilter.java
+++ b/frontend-server/src/main/java/shop/bluebooktle/frontend/config/filter/GuestIdFilter.java
@@ -1,0 +1,31 @@
+package shop.bluebooktle.frontend.config.filter;
+
+import java.io.IOException;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import shop.bluebooktle.frontend.util.CookieTokenUtil;
+
+@RequiredArgsConstructor
+public class GuestIdFilter implements Filter {
+
+	private final CookieTokenUtil cookieTokenUtil;
+
+	@Override
+	public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+		throws IOException, ServletException {
+
+		HttpServletRequest httpRequest = (HttpServletRequest)request;
+		HttpServletResponse httpResponse = (HttpServletResponse)response;
+
+		cookieTokenUtil.getOrCreateGuestId(httpRequest, httpResponse);
+
+		chain.doFilter(request, response);
+	}
+}

--- a/frontend-server/src/main/java/shop/bluebooktle/frontend/controller/BookController.java
+++ b/frontend-server/src/main/java/shop/bluebooktle/frontend/controller/BookController.java
@@ -61,7 +61,7 @@ public class BookController {
 	public String booksByCategoryPage(
 		Model model,
 		@RequestParam(value = "page", defaultValue = "0") int page,
-		@RequestParam(value = "size", defaultValue = "15") int size,
+		@RequestParam(value = "size", defaultValue = "20") int size,
 		@PathVariable Long categoryId
 	) {
 		log.info("요청된 카테고리 ID: {}", categoryId);

--- a/frontend-server/src/main/java/shop/bluebooktle/frontend/util/CookieTokenUtil.java
+++ b/frontend-server/src/main/java/shop/bluebooktle/frontend/util/CookieTokenUtil.java
@@ -1,9 +1,13 @@
 package shop.bluebooktle.frontend.util;
 
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
 
 import jakarta.servlet.http.Cookie;
@@ -74,5 +78,24 @@ public class CookieTokenUtil {
 		cookie.setPath("/");
 		cookie.setMaxAge(0);
 		response.addCookie(cookie);
+	}
+
+	public static final String GUEST_ID_COOKIE_NAME = "GUEST_ID";
+
+	public String getOrCreateGuestId(HttpServletRequest request, HttpServletResponse response) {
+		Optional<String> existing = getCookieValue(request, GUEST_ID_COOKIE_NAME);
+		if (existing.isPresent()) {
+			return existing.get();
+		}
+
+		String guestId = UUID.randomUUID().toString();
+		ResponseCookie cookie = ResponseCookie.from(GUEST_ID_COOKIE_NAME, guestId)
+			.httpOnly(true)
+			.path("/")
+			.maxAge(Duration.ofDays(7))
+			.build();
+		response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+
+		return guestId;
 	}
 }

--- a/frontend-server/src/main/resources/static/legal/privacy.html
+++ b/frontend-server/src/main/resources/static/legal/privacy.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <title>개인정보처리방침</title>
+    <link rel="stylesheet" href="/css/style.css">
+    <style>
+        .policy-wrapper {
+            padding: 4rem 2rem;
+            background-color: var(--kitsch-color-1);
+            color: var(--kitsch-text-dark);
+            border-radius: 12px;
+            box-shadow: 0 4px 10px rgba(0, 0, 0, 0.15);
+            max-width: 800px;
+            margin: 3rem auto;
+            line-height: 1.8;
+            font-size: 1.1rem;
+        }
+
+        .policy-wrapper h1 {
+            font-size: 2rem;
+            margin-bottom: 1.5rem;
+            color: var(--kitsch-color-4);
+            border-bottom: 2px dashed var(--kitsch-color-4);
+            padding-bottom: 0.5rem;
+        }
+
+        .policy-wrapper p {
+            white-space: pre-line;
+        }
+    </style>
+</head>
+<body>
+<div class="container-kitsch">
+    <div class="footer-logo-area-kitsch" style="text-align: center; margin-top: 2rem;">
+        <a class="logo-link-kitsch" href="/">
+            <h2 class="logo-main-kitsch display-font-kitsch">
+                Blue<span class="logo-alt-color-kitsch">Book</span>tle
+            </h2>
+        </a>
+        <p class="handwriting-font-kitsch">즐거운 책 읽기, 블루북틀과 함께!</p>
+    </div>
+
+    <div class="policy-wrapper">
+        <h1>개인정보처리방침</h1>
+        <p>
+            본 웹사이트는 회원가입 및 주문처리, 고객 응대를 위해 최소한의 개인정보(이름, 이메일, 주소 등)를 수집합니다.
+
+            수집된 정보는 명시된 목적 외에는 절대 사용되지 않으며, 보유 기간은 관련 법령에 따라 처리됩니다.
+
+            개인정보는 암호화된 방식으로 안전하게 저장되며, 제3자 제공 시에는 사전 동의를 받습니다.
+
+            사용자는 언제든지 자신의 개인정보에 대해 열람, 수정, 삭제를 요청할 수 있습니다.
+
+            당사는 개인정보 보호를 위해 최선을 다하며, 관련 문의는 고객센터로 접수해주시기 바랍니다.
+        </p>
+    </div>
+</div>
+</body>
+</html>

--- a/frontend-server/src/main/resources/static/legal/terms.html
+++ b/frontend-server/src/main/resources/static/legal/terms.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <title>이용약관</title>
+    <link rel="stylesheet" href="/css/style.css">
+    <style>
+        .policy-wrapper {
+            padding: 4rem 2rem;
+            background-color: var(--kitsch-color-1);
+            color: var(--kitsch-text-dark);
+            border-radius: 12px;
+            box-shadow: 0 4px 10px rgba(0, 0, 0, 0.15);
+            max-width: 800px;
+            margin: 3rem auto;
+            line-height: 1.8;
+            font-size: 1.1rem;
+        }
+
+        .policy-wrapper h1 {
+            font-size: 2rem;
+            margin-bottom: 1.5rem;
+            color: var(--kitsch-color-4);
+            border-bottom: 2px dashed var(--kitsch-color-4);
+            padding-bottom: 0.5rem;
+        }
+
+        .policy-wrapper p {
+            white-space: pre-line;
+        }
+    </style>
+</head>
+<body>
+<div class="container-kitsch">
+    <div class="footer-logo-area-kitsch" style="text-align: center; margin-top: 2rem;">
+        <a class="logo-link-kitsch" href="/">
+            <h2 class="logo-main-kitsch display-font-kitsch">
+                Blue<span class="logo-alt-color-kitsch">Book</span>tle
+            </h2>
+        </a>
+        <p class="handwriting-font-kitsch">즐거운 책 읽기, 블루북틀과 함께!</p>
+    </div>
+
+    <div class="policy-wrapper">
+        <h1>이용약관</h1>
+        <p>
+            본 웹사이트는 사용자의 편의를 위한 도서 검색, 주문, 결제 서비스를 제공합니다.
+
+            사용자는 사이트 이용 시 관련 법률 및 본 약관을 준수해야 하며, 서비스 운영자에게 피해를 주는 행위(해킹, 스팸 등)를 금지합니다.
+
+            회원가입을 통해 제공되는 기능은 등록된 회원에게 한정되며, 운영자는 사전 통보 없이 일부 서비스를 변경 또는 중단할 수 있습니다.
+        </p>
+    </div>
+</div>
+</body>
+</html>

--- a/frontend-server/src/main/resources/static/support/faq.html
+++ b/frontend-server/src/main/resources/static/support/faq.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <title>고객센터 (FAQ)</title>
+    <link rel="stylesheet" href="/css/style.css">
+    <style>
+        .policy-wrapper {
+            padding: 4rem 2rem;
+            background-color: var(--kitsch-color-1);
+            color: var(--kitsch-text-dark);
+            border-radius: 12px;
+            box-shadow: 0 4px 10px rgba(0, 0, 0, 0.15);
+            max-width: 800px;
+            margin: 3rem auto;
+            line-height: 1.8;
+            font-size: 1.1rem;
+        }
+
+        .policy-wrapper h1 {
+            font-size: 2rem;
+            margin-bottom: 1.5rem;
+            color: var(--kitsch-color-4);
+            border-bottom: 2px dashed var(--kitsch-color-4);
+            padding-bottom: 0.5rem;
+        }
+
+        .policy-wrapper p {
+            white-space: pre-line;
+        }
+
+        .policy-wrapper a {
+            color: var(--kitsch-color-4);
+            text-decoration: underline;
+        }
+    </style>
+</head>
+<body>
+<div class="container-kitsch">
+    <div class="footer-logo-area-kitsch" style="text-align: center; margin-top: 2rem;">
+        <a class="logo-link-kitsch" href="/">
+            <h2 class="logo-main-kitsch display-font-kitsch">
+                Blue<span class="logo-alt-color-kitsch">Book</span>tle
+            </h2>
+        </a>
+        <p class="handwriting-font-kitsch">즐거운 책 읽기, 블루북틀과 함께!</p>
+    </div>
+
+    <div class="policy-wrapper">
+        <h1>고객센터 (FAQ)</h1>
+        <p>
+            본 웹사이트는 서비스 운영을 하지 않는 학습용 프로젝트이므로 공식적인 고객센터는 존재하지 않습니다.
+
+            다만, 다음을 통해 프로젝트 정보를 확인하실 수 있습니다:
+
+            • Github: <a href="https://github.com/nhnacademy-be9-bluebooktle" target="_blank">Bluebooktle Repository</a>
+            • 운영 기간: 서버 종료 시까지
+
+            블루북틀 팀은 항상 키치하게 코딩하며 더 나은 프로젝트를 위해 노력하겠습니다 :)
+        </p>
+    </div>
+</div>
+</body>
+</html>

--- a/frontend-server/src/main/resources/static/support/faq.html
+++ b/frontend-server/src/main/resources/static/support/faq.html
@@ -56,7 +56,7 @@
             • Github: <a href="https://github.com/nhnacademy-be9-bluebooktle" target="_blank">Bluebooktle Repository</a>
             • 운영 기간: 서버 종료 시까지
 
-            블루북틀 팀은 항상 키치하게 코딩하며 더 나은 프로젝트를 위해 노력하겠습니다 :)
+            블루북틀 팀은 열심히 코딩하며 더 나은 프로젝트를 위해 노력하겠습니다 :)
         </p>
     </div>
 </div>

--- a/frontend-server/src/main/resources/templates/_fragments/footer.html
+++ b/frontend-server/src/main/resources/templates/_fragments/footer.html
@@ -8,17 +8,18 @@
                 <h2 class="logo-main-kitsch display-font-kitsch">Blue<span class="logo-alt-color-kitsch">Book</span>tle
                 </h2>
             </a>
-            <p class="handwriting-font-kitsch">즐거운 책 읽기, 키치한 스타일로!</p>
+            <p class="handwriting-font-kitsch">즐거운 책 읽기, 블루북틀과 함께!</p>
         </div>
         <div class="footer-links-kitsch">
-            <a th:href="@{/legal/terms}">이용약관</a>
-            <a th:href="@{/legal/privacy}">개인정보처리방침</a>
-            <a th:href="@{/support/faq}">고객센터</a>
+            <a href="/legal/terms.html" target="_blank">이용약관</a>
+            <a href="/legal/privacy.html" target="_blank">개인정보처리방침</a>
+            <a href="/support/faq.html" target="_blank">고객센터</a>
         </div>
         <div class="footer-social-kitsch">
-            <a href="#" target="_blank" title="Instagram"><i class="fab fa-instagram"></i></a>
-            <a href="#" target="_blank" title="Twitter"><i class="fab fa-twitter"></i></a>
-            <a href="#" target="_blank" title="Facebook"><i class="fab fa-facebook-f"></i></a>
+            <a href="https://github.com/nhnacademy-be9-bluebooktle" target="_blank" title="github"><i
+                    class="fab fa-github"></i></a>
+            <a href="https://sites.google.com/g.cnu.ac.kr/nhn/6%EA%B8%B0-%EA%B5%90%EC%9C%A1%EC%9A%B4%EC%98%81?authuser=0"
+               target="_blank" title="sw-academy"><i class="fab fa-solid fa-globe"></i></a>
         </div>
         <div class="footer-copyright-kitsch pixel-font-kitsch">
             &copy; <span th:text="${#dates.year(#dates.createNow())}">2024</span> Bluebooktle. All Rights Reserved.

--- a/frontend-server/src/main/resources/templates/book/book_list.html
+++ b/frontend-server/src/main/resources/templates/book/book_list.html
@@ -186,8 +186,10 @@
                         </div>
                     </div>
                 </a>
-
-                <button class="btn-kitsch primary-btn-kitsch add-to-cart-btn-kitsch retro-shadow-kitsch-small">
+                <input id="bookId" th:value="${item.bookId}" type="hidden">
+                <button class="btn-kitsch primary-btn-kitsch add-to-cart-btn-kitsch retro-shadow-kitsch-small"
+                        onclick="handleAddToCart(event)"
+                        type="button">
                     <i class="fas fa-shopping-basket"></i> 장바구니
                 </button>
             </div>
@@ -217,6 +219,23 @@
         </nav>
 
     </div>
+
+    <div class="modal-overlay-kitsch" id="addToCartSuccessModal" onclick="hideKitschModal('addToCartSuccessModal')"
+         style="display:none;">
+        <div class="modal-content-kitsch" onclick="event.stopPropagation();" style="max-width:400px; padding:2rem;">
+            <button class="modal-close-btn-kitsch" onclick="hideKitschModal('addToCartSuccessModal')"><i
+                    class="fas fa-times"></i></button>
+            <h3 style="margin-bottom: 1rem;">장바구니에 담겼습니다 🛒</h3>
+            <div style="display:flex; flex-direction:column; gap:0.5rem;">
+                <button class="btn-kitsch primary-btn-kitsch" onclick="hideKitschModal('addToCartSuccessModal')">
+                    쇼핑 계속하기
+                </button>
+                <a class="btn-kitsch secondary-btn-kitsch color2-kitsch" href="/cart" style="text-align:center;">
+                    장바구니로 이동
+                </a>
+            </div>
+        </div>
+    </div>
 </div>
 
 <th:block layout:fragment="page_scripts">
@@ -226,6 +245,35 @@
             filterButton.addEventListener('click', function () {
                 console.log('필터 버튼 클릭됨! 실제 필터 UI를 여기에 연결하세요.');
             });
+        }
+
+        function handleAddToCart(event) {
+            event.preventDefault();
+
+            const bookId = document.getElementById('bookId').value;
+            const quantity = 1;
+
+            const formData = new URLSearchParams();
+            formData.append("bookId", bookId);
+            formData.append("quantity", quantity);
+
+            fetch("/cart", {
+                method: 'POST',
+                body: formData,
+            }).then(response => {
+                console.log("response check")
+                console.log("response :" + response)
+                console.log("response :" + response.body)
+                if (response.ok) {
+                    showKitschModal('addToCartSuccessModal');
+                } else {
+                    alert('장바구니 담기에 실패했습니다.');
+                }
+            }).catch(() => {
+                alert('서버 오류가 발생했습니다.');
+            });
+
+            return false;
         }
     </script>
 </th:block>

--- a/frontend-server/src/main/resources/templates/main.html
+++ b/frontend-server/src/main/resources/templates/main.html
@@ -63,109 +63,141 @@
         <section class="section-padding-kitsch">
             <div class="container-kitsch">
                 <div class="section-header-kitsch">
-                    <h2 class="section-title-kitsch display-font-kitsch">추천 도서 <i
+                    <h2 class="section-title-kitsch display-font-kitsch">베스트셀러 도서 <i
                             class="fas fa-star highlight-pink-kitsch"></i></h2>
                     <p class="pixel-font-kitsch"
-                       style="margin-top: 0.5rem; font-size: 1.1em; color: var(--kitsch-color-1);">매일매일 새로운 도서
-                        업데이트!</p>
+                       style="margin-top: 0.5rem; font-size: 1.1em; color: var(--kitsch-color-1);">매주 핫한 도서들로 업데이트!</p>
                 </div>
-                <div class="book-grid-kitsch featured-grid-kitsch">
-                    <div class="book-item-kitsch">
-                        <a class="book-link-kitsch" href="/books/1">
+                <div class="book-grid-kitsch list-page-grid-kitsch">
+                    <div th:each="book, stat : ${hotBooks.content}" class="book-item-kitsch"
+                         th:classappend="${stat.index % 2 == 0} ? ' tilt-left-kitsch' : ' tilt-right-kitsch'">
+                        <a class="book-link-kitsch" th:href="@{/books/{id}(id=${book.bookId})}">
                             <div class="book-cover-wrap-kitsch">
-                                <img alt="도서 표지" class="book-cover-kitsch"
-                                     src="https://picsum.photos/255/484?random=101">
+                                <img th:src="${book.imgUrl}" alt="도서 표지" class="book-cover-kitsch"/>
+                                <div class="book-hover-overlay-kitsch">
+                                    <i class="fas fa-search-plus"></i>
+                                    <p class="pixel-font-kitsch">상세 보기</p>
+                                </div>
+                                <span th:if="${book.createdAt.until(T(java.time.LocalDateTime).now(), T(java.time.temporal.ChronoUnit).DAYS) <= 3}"
+                                      class="sticker-hot-kitsch pixel-font-kitsch">HOT</span>
+                            </div>
 
-                                <div class="book-hover-overlay-kitsch">
-                                    <i class="fas fa-search-plus"></i>
-                                    <p class="pixel-font-kitsch">상세 보기</p>
-                                </div>
-                                <span class="sticker-new-kitsch pixel-font-kitsch">NEW</span>
-                            </div>
                             <div class="book-info-kitsch">
                                 <h3 class="book-title-kitsch pixel-font-kitsch"
-                                    style="font-size: 1.2rem; color: var(--kitsch-color-4);">코딩 대모험</h3>
-                                <p class="book-author-kitsch book-author-pixel">글쓴이: 나코딩</p>
-                                <p class="book-price-kitsch pixel-font-kitsch">25,000원 <span
-                                        class="original-price-kitsch pixel-font-kitsch" style="font-size: 0.8em;">28,000원</span>
+                                    style="font-size: 1.2rem; color: var(--kitsch-color-4);"
+                                    th:text="${book.title}">도서 제목</h3>
+
+                                <p class="book-author-kitsch book-author-pixel">
+                            <span th:each="au, stat : ${book.authors}"
+                                  th:text="${au} + (${stat.last} ? '' : ', ')">저자</span>
                                 </p>
-                            </div>
-                        </a>
-                    </div>
-                    <div class="book-item-kitsch tilt-right-kitsch">
-                        <a class="book-link-kitsch" href="/books/2">
-                            <div class="book-cover-wrap-kitsch">
-                                <img alt="도서 표지" class="book-cover-kitsch"
-                                     src="https://picsum.photos/255/484?random=102">
-                                <div class="book-hover-overlay-kitsch">
-                                    <i class="fas fa-search-plus"></i>
-                                    <p class="pixel-font-kitsch">상세 보기</p>
-                                </div>
-                                <span class="sticker-hot-kitsch display-font-kitsch">HOT</span>
-                            </div>
-                            <div class="book-info-kitsch">
-                                <h3 class="book-title-kitsch pixel-font-kitsch"
-                                    style="font-size: 1.2rem; color: var(--kitsch-color-4);">레트로 픽셀 아트북</h3>
-                                <p class="book-author-kitsch book-author-pixel">만든이: 박도트</p>
-                                <p class="book-price-kitsch pixel-font-kitsch highlight-pink-kitsch">18,000원</p>
-                            </div>
-                        </a>
-                    </div>
-                    <div class="book-item-kitsch">
-                        <a class="book-link-kitsch" href="/books/3">
-                            <div class="book-cover-wrap-kitsch">
-                                <img alt="도서 표지" class="book-cover-kitsch"
-                                     src="https://picsum.photos/255/484?random=103">
-                                <div class="book-hover-overlay-kitsch">
-                                    <i class="fas fa-search-plus"></i>
-                                    <p class="pixel-font-kitsch">상세 보기</p>
-                                </div>
-                            </div>
-                            <div class="book-info-kitsch">
-                                <h3 class="book-title-kitsch pixel-font-kitsch"
-                                    style="font-size: 1.2em; color: var(--kitsch-color-4);">알록달록 웹디자인</h3>
-                                <p class="book-author-kitsch">김컬러 그림</p>
-                                <p class="book-price-kitsch pixel-font-kitsch">32,000원</p>
-                            </div>
-                        </a>
-                    </div>
-                    <div class="book-item-kitsch tilt-left-kitsch">
-                        <a class="book-link-kitsch" href="/books/4">
-                            <div class="book-cover-wrap-kitsch">
-                                <img alt="도서 표지" class="book-cover-kitsch"
-                                     src="https://picsum.photos/255/484?random=104">
-                                <div class="book-hover-overlay-kitsch">
-                                    <i class="fas fa-search-plus"></i>
-                                    <p class="pixel-font-kitsch">상세 보기</p>
-                                </div>
-                            </div>
-                            <div class="book-info-kitsch">
-                                <h3 class="book-title-kitsch pixel-font-kitsch"
-                                    style="font-size: 1.2rem; color: var(--kitsch-color-4);">나만의 작은 정원 만들기</h3>
-                                <p class="book-author-kitsch">이가든 글/사진</p>
-                                <p class="book-price-kitsch pixel-font-kitsch highlight-cyan-kitsch">21,500원 <span
-                                        class="original-price-kitsch pixel-font-kitsch" style="font-size: 0.8em;">23,000원</span>
+
+                                <p class="book-price-kitsch pixel-font-kitsch">
+                                    <span th:text="${#numbers.formatDecimal(book.salePrice, 0, 'COMMA', 0, 'NONE')} + '원'">0원</span>
+                                    <span th:if="${book.salePrice < book.price}"
+                                          class="original-price-kitsch pixel-font-kitsch"
+                                          style="font-size: 0.8em;"
+                                          th:text="${#numbers.formatDecimal(book.price, 0, 'COMMA', 0, 'NONE')} + '원'">0원</span>
                                 </p>
                             </div>
                         </a>
                     </div>
                 </div>
+
+                <nav class="pagination-kitsch" aria-label="메인 페이지 HOT 도서 페이징">
+                    <a th:if="${hotBooks.hasPrevious()}" class="page-btn-kitsch prev-kitsch retro-shadow-kitsch-small"
+                       th:href="@{/(page=${hotBooks.number - 1}, size=${size})}">
+                        <i class="fas fa-angle-left"></i> 이전
+                    </a>
+
+                    <a th:each="i : ${#numbers.sequence(0, hotBooks.totalPages - 1)}"
+                       class="page-btn-kitsch num-kitsch retro-shadow-kitsch-small"
+                       th:classappend="${i == hotBooks.number} ? ' active-kitsch' : ''"
+                       th:href="@{/(page=${i}, size=${size})}"
+                       th:text="${i + 1}">1</a>
+
+                    <a th:if="${hotBooks.hasNext()}" class="page-btn-kitsch next-kitsch retro-shadow-kitsch-small"
+                       th:href="@{/(page=${hotBooks.number + 1}, size=${size})}">
+                        다음 <i class="fas fa-angle-right"></i>
+                    </a>
+                </nav>
             </div>
         </section>
+
+
+        <section class="section-padding-kitsch">
+            <div class="container-kitsch">
+                <div class="section-header-kitsch">
+                    <h2 class="section-title-kitsch display-font-kitsch">신규 도서 <i
+                            class="fas fa-bolt highlight-pink-kitsch"></i></h2>
+                    <p class="pixel-font-kitsch"
+                       style="margin-top: 0.5rem; font-size: 1.1em; color: var(--kitsch-color-1);">새롭게 입고된 따끈따끈한
+                        도서들!</p>
+                </div>
+                <div class="book-grid-kitsch list-page-grid-kitsch">
+                    <div th:each="book, stat : ${newBooks.content}" class="book-item-kitsch"
+                         th:classappend="${stat.index % 2 == 0} ? ' tilt-left-kitsch' : ' tilt-right-kitsch'">
+                        <a class="book-link-kitsch" th:href="@{/books/{id}(id=${book.bookId})}">
+                            <div class="book-cover-wrap-kitsch">
+                                <img th:src="${book.imgUrl}" alt="도서 표지" class="book-cover-kitsch"/>
+                                <div class="book-hover-overlay-kitsch">
+                                    <i class="fas fa-search-plus"></i>
+                                    <p class="pixel-font-kitsch">상세 보기</p>
+                                </div>
+                                <span th:if="${book.createdAt.until(T(java.time.LocalDateTime).now(), T(java.time.temporal.ChronoUnit).DAYS) <= 7}"
+                                      class="sticker-new-kitsch pixel-font-kitsch">NEW</span>
+                            </div>
+
+                            <div class="book-info-kitsch">
+                                <h3 class="book-title-kitsch pixel-font-kitsch"
+                                    style="font-size: 1.2rem; color: var(--kitsch-color-4);"
+                                    th:text="${book.title}">도서 제목</h3>
+
+                                <p class="book-author-kitsch book-author-pixel">
+                            <span th:each="au, stat : ${book.authors}"
+                                  th:text="${au} + (${stat.last} ? '' : ', ')">저자</span>
+                                </p>
+
+                                <p class="book-price-kitsch pixel-font-kitsch">
+                                    <span th:text="${#numbers.formatDecimal(book.salePrice, 0, 'COMMA', 0, 'NONE')} + '원'">0원</span>
+                                    <span th:if="${book.salePrice < book.price}"
+                                          class="original-price-kitsch pixel-font-kitsch"
+                                          style="font-size: 0.8em;"
+                                          th:text="${#numbers.formatDecimal(book.price, 0, 'COMMA', 0, 'NONE')} + '원'">0원</span>
+                                </p>
+                            </div>
+                        </a>
+                    </div>
+                </div>
+
+                <nav class="pagination-kitsch" aria-label="메인 페이지 신규 도서 페이징">
+                    <a th:if="${newBooks.hasPrevious()}" class="page-btn-kitsch prev-kitsch retro-shadow-kitsch-small"
+                       th:href="@{/(page=${newBooks.number - 1}, size=${size})}">
+                        <i class="fas fa-angle-left"></i> 이전
+                    </a>
+
+                    <a th:each="i : ${#numbers.sequence(0, newBooks.totalPages - 1)}"
+                       class="page-btn-kitsch num-kitsch retro-shadow-kitsch-small"
+                       th:classappend="${i == newBooks.number} ? ' active-kitsch' : ''"
+                       th:href="@{/(page=${i}, size=${size})}"
+                       th:text="${i + 1}">1</a>
+
+                    <a th:if="${newBooks.hasNext()}" class="page-btn-kitsch next-kitsch retro-shadow-kitsch-small"
+                       th:href="@{/(page=${newBooks.number + 1}, size=${size})}">
+                        다음 <i class="fas fa-angle-right"></i>
+                    </a>
+                </nav>
+            </div>
+        </section>
+
+
         <section class="hero-section-main">
             <div class="hero-bg-pattern-kitsch"></div>
             <div class="container-kitsch hero-content-kitsch">
-                <h2 class="hero-title-kitsch display-font-kitsch">오늘의 <span class="highlight-pink-kitsch">도서</span>
-                    발견!</h2>
+                <h2 class="hero-title-kitsch display-font-kitsch">책이란 <span
+                        class="highlight-pink-kitsch">넓디넓은 시간의 바다</span>를 지나가는 배이다</h2>
                 <p class="hero-subtitle-kitsch pixel-font-kitsch" style="font-size: 1.3em; line-height: 1.5;">지금 바로
                     Bluebooktle에서 특별하고 재미난 책들을 만나보세요!</p>
-                <form action="/books" class="search-bar-main" method="get">
-                    <input class="input-kitsch retro-shadow-kitsch-small" name="query" placeholder="어떤 책을 찾으세요?"
-                           type="text">
-                    <button class="btn-kitsch primary-btn-kitsch retro-shadow-kitsch" type="submit"><i
-                            class="fas fa-search"></i> 검색
-                    </button>
-                </form>
             </div>
         </section>
 
@@ -213,7 +245,7 @@
                     'retro-shadow-kitsch-small',
                     colorClasses[idx % colorClasses.length]
                 ].join(' ');
-                
+
                 const i = document.createElement('i');
                 i.className = `fas ${iconClasses[idx % iconClasses.length]}`;
                 a.appendChild(i);


### PR DESCRIPTION
## 관련 이슈


## 작업 내용

- 메인페이지에 베스트셀러 도서와 신규 도서 보기 생성
- 기존 : 비회원 ID 생성 시점 "/" 주소에서 생성 (링크로 받아 작업 시 문제발생) -> Global Filter 만들어 해결
- footer에 이용약관 등 약식으로 생성
- footer에 깃헙 및 sw아카데미 사이트 연결
- 페이징 항목 20개로 설정

## 확인 방법

## 스크린샷 (선택 사항)

<img width="315" alt="image" src="https://github.com/user-attachments/assets/e7fe7469-909e-41b5-8d2d-cfe76b941a8b" />


## 브레이킹 체인지 여부



## 연관 PR

-

## 체크리스트

- [ ] 관련 이슈번호를 추가 했나요?
- [ ] 리뷰어와 해당하는 레이블을 추가했나요?
- [ ] 무엇을 변경했는지 충분히 설명하고 있나요?