### PR TITLE
[#124][BACK][결제] - 결제 취소 API 추가

### DIFF
--- a/backend-server/src/main/java/shop/bluebooktle/backend/order/mq/listener/OrderCancelRabbitListener.java
+++ b/backend-server/src/main/java/shop/bluebooktle/backend/order/mq/listener/OrderCancelRabbitListener.java
@@ -20,7 +20,7 @@ public class OrderCancelRabbitListener {
 			return;
 		}
 		try {
-			orderService.cancelOrderInternal(message.orderId());
+			orderService.cancelOrderListener(message.orderId());
 		} catch (Exception e) {
 			log.error("order cancel failed. orderId: {}, {}", message.orderId(), e.getMessage(), e);
 		}

--- a/backend-server/src/main/java/shop/bluebooktle/backend/order/repository/OrderRepository.java
+++ b/backend-server/src/main/java/shop/bluebooktle/backend/order/repository/OrderRepository.java
@@ -43,7 +43,9 @@ public interface OrderRepository extends JpaRepository<Order, Long>, OrderQueryR
 
 	@EntityGraph(attributePaths = {
 		"orderState",
-		"bookOrders.book.bookImgs.img"
+		"bookOrders.book.bookImgs.img",
+		"user",
+		"payment.paymentDetail"
 	})
 	Optional<Order> findByOrderKey(String orderKey);
 

--- a/backend-server/src/main/java/shop/bluebooktle/backend/order/service/OrderService.java
+++ b/backend-server/src/main/java/shop/bluebooktle/backend/order/service/OrderService.java
@@ -3,6 +3,7 @@ package shop.bluebooktle.backend.order.service;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import shop.bluebooktle.backend.order.entity.Order;
 import shop.bluebooktle.common.domain.order.OrderStatus;
 import shop.bluebooktle.common.dto.order.request.AdminOrderSearchRequest;
 import shop.bluebooktle.common.dto.order.request.OrderCreateRequest;
@@ -26,7 +27,9 @@ public interface OrderService {
 
 	void cancelOrderNonMember(String orderKey);
 
-	void cancelOrderInternal(Long orderId);
+	void cancelOrderInternal(Order order);
+
+	void cancelOrderListener(Long orderId);
 
 	Page<AdminOrderListResponse> searchOrders(AdminOrderSearchRequest searchRequest, Pageable pageable);
 

--- a/backend-server/src/main/java/shop/bluebooktle/backend/payment/client/TossPaymentClient.java
+++ b/backend-server/src/main/java/shop/bluebooktle/backend/payment/client/TossPaymentClient.java
@@ -2,12 +2,15 @@ package shop.bluebooktle.backend.payment.client;
 
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 
 import shop.bluebooktle.backend.config.FeignClientLoggingConfig;
+import shop.bluebooktle.backend.payment.dto.request.TossApiPaymentCancelRequest;
 import shop.bluebooktle.backend.payment.dto.request.TossApiPaymentConfirmRequest;
+import shop.bluebooktle.backend.payment.dto.response.TossApiPaymentCancelSuccessResponse;
 import shop.bluebooktle.backend.payment.dto.response.TossApiPaymentConfirmSuccessResponse;
 
 @FeignClient(
@@ -21,5 +24,12 @@ public interface TossPaymentClient {
 	TossApiPaymentConfirmSuccessResponse confirmPayment(
 		@RequestHeader("Authorization") String authorizationHeader,
 		@RequestBody TossApiPaymentConfirmRequest request
+	);
+
+	@PostMapping(value = "/payments/{paymentKey}/cancel", consumes = MediaType.APPLICATION_JSON_VALUE)
+	TossApiPaymentCancelSuccessResponse cancelPayment(
+		@RequestHeader("Authorization") String authorizationHeader,
+		@PathVariable(name = "paymentKey") String paymentKey,
+		@RequestBody TossApiPaymentCancelRequest request
 	);
 }

--- a/backend-server/src/main/java/shop/bluebooktle/backend/payment/controller/PaymentController.java
+++ b/backend-server/src/main/java/shop/bluebooktle/backend/payment/controller/PaymentController.java
@@ -11,6 +11,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import shop.bluebooktle.backend.payment.service.PaymentService;
 import shop.bluebooktle.common.dto.common.JsendResponse;
+import shop.bluebooktle.common.dto.payment.request.PaymentCancelRequest;
 import shop.bluebooktle.common.dto.payment.request.PaymentConfirmRequest;
 import shop.bluebooktle.common.dto.payment.response.PaymentConfirmResponse;
 
@@ -32,5 +33,14 @@ public class PaymentController {
 			request.amount().intValue()
 		);
 		return ResponseEntity.ok(JsendResponse.success(responsePayload));
+	}
+
+	@PostMapping("/{gatewayName}/cancel")
+	public ResponseEntity<JsendResponse<Void>> cancel(
+		@PathVariable String gatewayName,
+		@Valid @RequestBody PaymentCancelRequest request) throws Exception {
+		paymentService.cancelPayment(request, gatewayName.toUpperCase());
+
+		return ResponseEntity.ok(JsendResponse.success());
 	}
 }

--- a/backend-server/src/main/java/shop/bluebooktle/backend/payment/controller/PaymentController.java
+++ b/backend-server/src/main/java/shop/bluebooktle/backend/payment/controller/PaymentController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import shop.bluebooktle.backend.payment.service.PaymentService;
@@ -23,6 +24,7 @@ import shop.bluebooktle.common.security.UserPrincipal;
 public class PaymentController {
 	private final PaymentService paymentService;
 
+	@Operation(summary = "결제 확정", description = "외부 서비스 결제 이후 결제 완료 데이터를 저장합니다. ")
 	@PostMapping("/{gateway-name}/confirm")
 	public ResponseEntity<JsendResponse<PaymentConfirmResponse>> confirmPayment(
 		@PathVariable(name = "gateway-name") String gatewayName,
@@ -37,6 +39,7 @@ public class PaymentController {
 		return ResponseEntity.ok(JsendResponse.success(responsePayload));
 	}
 
+	@Operation(summary = "결제 취소", description = "결제를 취소합니다.")
 	@PostMapping("/{gateway-name}/cancel")
 	public ResponseEntity<JsendResponse<Void>> cancel(
 		@PathVariable(name = "gateway-name") String gatewayName,

--- a/backend-server/src/main/java/shop/bluebooktle/backend/payment/controller/PaymentController.java
+++ b/backend-server/src/main/java/shop/bluebooktle/backend/payment/controller/PaymentController.java
@@ -1,6 +1,7 @@
 package shop.bluebooktle.backend.payment.controller;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -14,6 +15,7 @@ import shop.bluebooktle.common.dto.common.JsendResponse;
 import shop.bluebooktle.common.dto.payment.request.PaymentCancelRequest;
 import shop.bluebooktle.common.dto.payment.request.PaymentConfirmRequest;
 import shop.bluebooktle.common.dto.payment.response.PaymentConfirmResponse;
+import shop.bluebooktle.common.security.UserPrincipal;
 
 @RestController
 @RequestMapping("/api/payments")
@@ -21,10 +23,10 @@ import shop.bluebooktle.common.dto.payment.response.PaymentConfirmResponse;
 public class PaymentController {
 	private final PaymentService paymentService;
 
-	@PostMapping("/{gatewayName}/confirm")
+	@PostMapping("/{gateway-name}/confirm")
 	public ResponseEntity<JsendResponse<PaymentConfirmResponse>> confirmPayment(
-		@PathVariable String gatewayName,
-		@Valid @RequestBody PaymentConfirmRequest request) throws Exception {
+		@PathVariable(name = "gateway-name") String gatewayName,
+		@Valid @RequestBody PaymentConfirmRequest request) {
 		paymentService.confirmPayment(request, gatewayName.toUpperCase());
 
 		PaymentConfirmResponse responsePayload = new PaymentConfirmResponse(
@@ -35,11 +37,14 @@ public class PaymentController {
 		return ResponseEntity.ok(JsendResponse.success(responsePayload));
 	}
 
-	@PostMapping("/{gatewayName}/cancel")
+	@PostMapping("/{gateway-name}/cancel")
 	public ResponseEntity<JsendResponse<Void>> cancel(
-		@PathVariable String gatewayName,
-		@Valid @RequestBody PaymentCancelRequest request) throws Exception {
-		paymentService.cancelPayment(request, gatewayName.toUpperCase());
+		@PathVariable(name = "gateway-name") String gatewayName,
+		@Valid @RequestBody PaymentCancelRequest request,
+		@AuthenticationPrincipal UserPrincipal userPrincipal
+	) {
+		paymentService.cancelPayment(request, gatewayName.toUpperCase(),
+			userPrincipal != null ? userPrincipal.getUserId() : null);
 
 		return ResponseEntity.ok(JsendResponse.success());
 	}

--- a/backend-server/src/main/java/shop/bluebooktle/backend/payment/dto/request/GenericPaymentCancelRequest.java
+++ b/backend-server/src/main/java/shop/bluebooktle/backend/payment/dto/request/GenericPaymentCancelRequest.java
@@ -1,0 +1,8 @@
+package shop.bluebooktle.backend.payment.dto.request;
+
+public record GenericPaymentCancelRequest(
+	String paymentKey,
+
+	String cancelReason
+) {
+}

--- a/backend-server/src/main/java/shop/bluebooktle/backend/payment/dto/request/TossApiPaymentCancelRequest.java
+++ b/backend-server/src/main/java/shop/bluebooktle/backend/payment/dto/request/TossApiPaymentCancelRequest.java
@@ -1,0 +1,9 @@
+package shop.bluebooktle.backend.payment.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record TossApiPaymentCancelRequest(
+	@NotBlank @Size(min = 1, max = 200) String cancelReason
+) {
+}

--- a/backend-server/src/main/java/shop/bluebooktle/backend/payment/dto/response/GenericPaymentCancelResponse.java
+++ b/backend-server/src/main/java/shop/bluebooktle/backend/payment/dto/response/GenericPaymentCancelResponse.java
@@ -3,12 +3,12 @@ package shop.bluebooktle.backend.payment.dto.response;
 import java.math.BigDecimal;
 import java.util.Map;
 
-public record GenericPaymentConfirmResponse(
+public record GenericPaymentCancelResponse(
 	String transactionId,
 
 	String orderId,
 
-	BigDecimal confirmedAmount,
+	BigDecimal canceledAmount,
 
 	PaymentStatus status,
 
@@ -16,5 +16,4 @@ public record GenericPaymentConfirmResponse(
 
 	Map<String, Object> additionalData
 ) {
-
 }

--- a/backend-server/src/main/java/shop/bluebooktle/backend/payment/dto/response/PaymentStatus.java
+++ b/backend-server/src/main/java/shop/bluebooktle/backend/payment/dto/response/PaymentStatus.java
@@ -1,0 +1,9 @@
+package shop.bluebooktle.backend.payment.dto.response;
+
+public enum PaymentStatus {
+	SUCCESS,
+	FAILURE,
+	PENDING,
+	CANCELED,
+	UNKNOWN
+}

--- a/backend-server/src/main/java/shop/bluebooktle/backend/payment/dto/response/TossApiPaymentCancelSuccessResponse.java
+++ b/backend-server/src/main/java/shop/bluebooktle/backend/payment/dto/response/TossApiPaymentCancelSuccessResponse.java
@@ -1,0 +1,72 @@
+package shop.bluebooktle.backend.payment.dto.response;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.List;
+
+public record TossApiPaymentCancelSuccessResponse(
+	String mId, // 상점 아이디
+	String version, // API 버전
+	String paymentKey, // 결제의 키 값
+	String orderId, // 주문 ID
+	String orderName, // 주문명
+	String currency, // 통화 (KRW 등)
+	String method, // 결제 수단 (e.g., "간편결제")
+	BigDecimal totalAmount, // 총 결제 금액
+	BigDecimal balanceAmount, // 취소 후 남은 금액
+	String status, // 결제 상태 (e.g., CANCELED)
+	OffsetDateTime requestedAt, // 결제 요청 시각
+	OffsetDateTime approvedAt, // 결제 승인 시각
+	boolean useEscrow, // 에스크로 사용 여부
+	String lastTransactionKey, // 마지막 거래의 키
+	BigDecimal suppliedAmount, // 공급가액
+	BigDecimal vat, // 부가세
+	BigDecimal taxFreeAmount, // 면세액
+	boolean isPartialCancelable, // 부분 취소 가능 여부
+	List<Cancel> cancels, // 취소 이력
+	EasyPay easyPay, // 간편결제 정보
+	String country, // 국가 코드 (e.g., "KR")
+	Receipt receipt, // 영수증 정보
+	Failure failure // 실패 정보
+) {
+
+	/**
+	 * 취소 이력 상세 정보
+	 */
+	public record Cancel(
+		BigDecimal cancelAmount, // 취소된 금액
+		String cancelReason, // 취소 사유
+		BigDecimal taxFreeAmount, // 취소된 금액 중 면세 금액
+		BigDecimal taxExemptionAmount, // 과세 제외 금액
+		BigDecimal refundableAmount, // 환불 가능한 잔액
+		OffsetDateTime canceledAt, // 취소된 시각
+		String transactionKey, // 취소 거래 키
+		String receiptKey, // 취소 영수증 키
+		String cancelStatus // 취소 상태 (e.g., DONE)
+	) {
+	}
+
+	/**
+	 * 간편결제 정보
+	 */
+	public record EasyPay(
+		String provider, // 간편결제 제공자 (e.g., "토스페이")
+		BigDecimal amount, // 결제 금액
+		BigDecimal discountAmount // 할인 금액
+	) {
+	}
+
+	/**
+	 * 영수증 정보
+	 */
+	public record Receipt(
+		String url // 영수증 URL
+	) {
+	}
+
+	public record Failure(
+		String code, // 오류 코드
+		String message // 오류 메시지
+	) {
+	}
+}

--- a/backend-server/src/main/java/shop/bluebooktle/backend/payment/entity/PaymentDetail.java
+++ b/backend-server/src/main/java/shop/bluebooktle/backend/payment/entity/PaymentDetail.java
@@ -1,10 +1,15 @@
 package shop.bluebooktle.backend.payment.entity;
 
+import java.time.LocalDateTime;
+
+import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -18,6 +23,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import shop.bluebooktle.common.domain.payment.PaymentStatus;
 import shop.bluebooktle.common.entity.BaseEntity;
 
 @Entity
@@ -39,12 +45,31 @@ public class PaymentDetail extends BaseEntity {
 	@JoinColumn(name = "payment_type_id", nullable = false)
 	private PaymentType paymentType;
 
-	@Column(name = "`key`", length = 255)
-	private String key;
+	@Column(name = "payment_key", length = 255)
+	private String paymentKey;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "payment_status", nullable = false)
+	@ColumnDefault("'READY'")
+	private PaymentStatus paymentStatus;
+
+	@Column(name = "requested_at", nullable = false)
+	private LocalDateTime requestedAt;
+
+	@Column(name = "approved_at")
+	private LocalDateTime approvedAt;
 
 	@Builder
-	public PaymentDetail(PaymentType paymentType, String key) {
+	public PaymentDetail(PaymentType paymentType, String paymentKey, PaymentStatus paymentStatus,
+		LocalDateTime requestedAt, LocalDateTime approvedAt) {
 		this.paymentType = paymentType;
-		this.key = key;
+		this.paymentKey = paymentKey;
+		this.paymentStatus = paymentStatus == null ? PaymentStatus.READY : paymentStatus;
+		this.requestedAt = requestedAt == null ? LocalDateTime.now() : requestedAt;
+		this.approvedAt = approvedAt;
+	}
+
+	public void updateStatus(PaymentStatus newStatus) {
+		this.paymentStatus = newStatus;
 	}
 }

--- a/backend-server/src/main/java/shop/bluebooktle/backend/payment/gateway/PaymentGateway.java
+++ b/backend-server/src/main/java/shop/bluebooktle/backend/payment/gateway/PaymentGateway.java
@@ -1,8 +1,8 @@
 package shop.bluebooktle.backend.payment.gateway;
 
+import shop.bluebooktle.backend.payment.dto.request.GenericPaymentCancelRequest;
 import shop.bluebooktle.backend.payment.dto.response.GenericPaymentCancelResponse;
 import shop.bluebooktle.backend.payment.dto.response.GenericPaymentConfirmResponse;
-import shop.bluebooktle.common.dto.payment.request.PaymentCancelRequest;
 import shop.bluebooktle.common.dto.payment.request.PaymentConfirmRequest;
 
 public interface PaymentGateway {
@@ -11,5 +11,5 @@ public interface PaymentGateway {
 
 	GenericPaymentConfirmResponse confirmPayment(PaymentConfirmRequest commonRequest);
 
-	GenericPaymentCancelResponse cancelPayment(PaymentCancelRequest request);
+	GenericPaymentCancelResponse cancelPayment(GenericPaymentCancelRequest commonRequest);
 }

--- a/backend-server/src/main/java/shop/bluebooktle/backend/payment/gateway/PaymentGateway.java
+++ b/backend-server/src/main/java/shop/bluebooktle/backend/payment/gateway/PaymentGateway.java
@@ -1,6 +1,8 @@
 package shop.bluebooktle.backend.payment.gateway;
 
+import shop.bluebooktle.backend.payment.dto.response.GenericPaymentCancelResponse;
 import shop.bluebooktle.backend.payment.dto.response.GenericPaymentConfirmResponse;
+import shop.bluebooktle.common.dto.payment.request.PaymentCancelRequest;
 import shop.bluebooktle.common.dto.payment.request.PaymentConfirmRequest;
 
 public interface PaymentGateway {
@@ -8,4 +10,6 @@ public interface PaymentGateway {
 	String getGatewayName();
 
 	GenericPaymentConfirmResponse confirmPayment(PaymentConfirmRequest commonRequest);
+
+	GenericPaymentCancelResponse cancelPayment(PaymentCancelRequest request);
 }

--- a/backend-server/src/main/java/shop/bluebooktle/backend/payment/gateway/impl/TossPaymentGatewayImpl.java
+++ b/backend-server/src/main/java/shop/bluebooktle/backend/payment/gateway/impl/TossPaymentGatewayImpl.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Component;
 import feign.FeignException;
 import lombok.RequiredArgsConstructor;
 import shop.bluebooktle.backend.payment.client.TossPaymentClient;
+import shop.bluebooktle.backend.payment.dto.request.GenericPaymentCancelRequest;
 import shop.bluebooktle.backend.payment.dto.request.TossApiPaymentCancelRequest;
 import shop.bluebooktle.backend.payment.dto.request.TossApiPaymentConfirmRequest;
 import shop.bluebooktle.backend.payment.dto.response.GenericPaymentCancelResponse;
@@ -21,7 +22,6 @@ import shop.bluebooktle.backend.payment.dto.response.PaymentStatus;
 import shop.bluebooktle.backend.payment.dto.response.TossApiPaymentCancelSuccessResponse;
 import shop.bluebooktle.backend.payment.dto.response.TossApiPaymentConfirmSuccessResponse;
 import shop.bluebooktle.backend.payment.gateway.PaymentGateway;
-import shop.bluebooktle.common.dto.payment.request.PaymentCancelRequest;
 import shop.bluebooktle.common.dto.payment.request.PaymentConfirmRequest;
 
 @Component("TOSS")
@@ -100,7 +100,7 @@ public class TossPaymentGatewayImpl implements PaymentGateway {
 	}
 
 	@Override
-	public GenericPaymentCancelResponse cancelPayment(PaymentCancelRequest request) {
+	public GenericPaymentCancelResponse cancelPayment(GenericPaymentCancelRequest request) {
 		TossApiPaymentCancelRequest tossSpecificRequest = new TossApiPaymentCancelRequest(
 			request.cancelReason()
 		);

--- a/backend-server/src/main/java/shop/bluebooktle/backend/payment/repository/PaymentDetailRepository.java
+++ b/backend-server/src/main/java/shop/bluebooktle/backend/payment/repository/PaymentDetailRepository.java
@@ -1,8 +1,11 @@
 package shop.bluebooktle.backend.payment.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import shop.bluebooktle.backend.payment.entity.PaymentDetail;
 
 public interface PaymentDetailRepository extends JpaRepository<PaymentDetail, Long> {
+	Optional<PaymentDetail> findByPaymentKey(String s);
 }

--- a/backend-server/src/main/java/shop/bluebooktle/backend/payment/repository/PaymentRepository.java
+++ b/backend-server/src/main/java/shop/bluebooktle/backend/payment/repository/PaymentRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import shop.bluebooktle.backend.order.entity.Order;
 import shop.bluebooktle.backend.payment.entity.Payment;
+import shop.bluebooktle.backend.payment.entity.PaymentDetail;
 import shop.bluebooktle.common.domain.order.OrderStatus;
 import shop.bluebooktle.common.entity.auth.User;
 
@@ -16,6 +17,8 @@ public interface PaymentRepository extends JpaRepository<Payment, Long> {
 	Optional<Payment> findById(long id);
 
 	Optional<Payment> findByOrder(Order order);
+
+	Optional<Payment> findByPaymentDetail(PaymentDetail paymentDetail);
 
 	@EntityGraph(attributePaths = {"order", "order.orderState"})
 	Page<Payment> findByOrder_User(User user, Pageable pageable);

--- a/backend-server/src/main/java/shop/bluebooktle/backend/payment/service/PaymentService.java
+++ b/backend-server/src/main/java/shop/bluebooktle/backend/payment/service/PaymentService.java
@@ -6,5 +6,5 @@ import shop.bluebooktle.common.dto.payment.request.PaymentConfirmRequest;
 public interface PaymentService {
 	void confirmPayment(PaymentConfirmRequest request, String gatewayName);
 
-	void cancelPayment(PaymentCancelRequest request, String gatewayName);
+	void cancelPayment(PaymentCancelRequest request, String gatewayName, Long userId);
 }

--- a/backend-server/src/main/java/shop/bluebooktle/backend/payment/service/PaymentService.java
+++ b/backend-server/src/main/java/shop/bluebooktle/backend/payment/service/PaymentService.java
@@ -1,7 +1,10 @@
 package shop.bluebooktle.backend.payment.service;
 
+import shop.bluebooktle.common.dto.payment.request.PaymentCancelRequest;
 import shop.bluebooktle.common.dto.payment.request.PaymentConfirmRequest;
 
 public interface PaymentService {
 	void confirmPayment(PaymentConfirmRequest request, String gatewayName);
+
+	void cancelPayment(PaymentCancelRequest request, String gatewayName);
 }

--- a/backend-server/src/main/resources/application-local.yml
+++ b/backend-server/src/main/resources/application-local.yml
@@ -7,7 +7,7 @@ spring:
     jdbc:
       initialize-schema: never
   datasource:
-    url: jdbc:mysql://s4.java21.net:13306/nhn_academy_123
+    url: jdbc:mysql://localhost:3306/bluebooktle
     username: ${MYSQL_USERNAME}
     password: ${MYSQL_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver

--- a/backend-server/src/main/resources/schema.sql
+++ b/backend-server/src/main/resources/schema.sql
@@ -167,11 +167,14 @@ CREATE TABLE `packaging_option`
 
 CREATE TABLE `payment_detail`
 (
-    `payment_detail_id` bigint       NOT NULL AUTO_INCREMENT,
-    `payment_type_id`   bigint       NOT NULL,
-    `key`               varchar(255) NULL,
-    `created_at`        timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    `deleted_at`        timestamp    NULL,
+    `payment_detail_id` bigint                                                                                                      NOT NULL AUTO_INCREMENT,
+    `payment_type_id`   bigint                                                                                                      NOT NULL,
+    `payment_key`       varchar(255)                                                                                                NULL,
+    `payment_status`    ENUM ('READY','IN_PROGRESS','WAITING_FOR_DEPOSIT','DONE','CANCELED','PARTIAL_CANCELED','ABORTED','EXPIRED') NOT NULL DEFAULT 'READY',
+    `requested_at`      timestamp                                                                                                   NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `approved_at`       timestamp                                                                                                   NULL,
+    `created_at`        timestamp                                                                                                   NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `deleted_at`        timestamp                                                                                                   NULL,
 
     CONSTRAINT `PK_PAYMENT_DETAIL` PRIMARY KEY (`payment_detail_id`),
     CONSTRAINT `FK_payment_detail_payment_type_id_payment_type`

--- a/backend-server/src/test/java/shop/bluebooktle/backend/book/controller/AuthorControllerTest.java
+++ b/backend-server/src/test/java/shop/bluebooktle/backend/book/controller/AuthorControllerTest.java
@@ -58,6 +58,8 @@ public class AuthorControllerTest {
 			.name("New Author")
 			.build();
 
+		doNothing().when(authorService).registerAuthor(any());
+
 		mockMvc.perform(post("/api/authors")
 				.with(csrf())
 				.contentType(MediaType.APPLICATION_JSON)

--- a/common-module/src/main/java/shop/bluebooktle/common/domain/payment/PaymentStatus.java
+++ b/common-module/src/main/java/shop/bluebooktle/common/domain/payment/PaymentStatus.java
@@ -1,0 +1,19 @@
+package shop.bluebooktle.common.domain.payment;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum PaymentStatus {
+	READY("준비"),
+	IN_PROGRESS("진행중"),
+	WAITING_FOR_DEPOSIT("입금대기"),
+	DONE("결제완료"),
+	CANCELED("결제취소"),
+	PARTIAL_CANCELED("부분취소"),
+	ABORTED("결제승인실패"),
+	EXPIRED("결제유효시간만료");
+
+	private final String description;
+}

--- a/common-module/src/main/java/shop/bluebooktle/common/dto/payment/request/PaymentCancelRequest.java
+++ b/common-module/src/main/java/shop/bluebooktle/common/dto/payment/request/PaymentCancelRequest.java
@@ -1,0 +1,13 @@
+package shop.bluebooktle.common.dto.payment.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record PaymentCancelRequest(
+	@NotBlank
+	@Size(min = 1, max = 255)
+	String paymentKey,
+	
+	String cancelReason
+) {
+}

--- a/common-module/src/main/java/shop/bluebooktle/common/dto/payment/request/PaymentCancelRequest.java
+++ b/common-module/src/main/java/shop/bluebooktle/common/dto/payment/request/PaymentCancelRequest.java
@@ -6,8 +6,8 @@ import jakarta.validation.constraints.Size;
 public record PaymentCancelRequest(
 	@NotBlank
 	@Size(min = 1, max = 255)
-	String paymentKey,
-	
+	String orderKey,
+
 	String cancelReason
 ) {
 }

--- a/common-module/src/main/java/shop/bluebooktle/common/exception/ErrorCode.java
+++ b/common-module/src/main/java/shop/bluebooktle/common/exception/ErrorCode.java
@@ -160,6 +160,8 @@ public enum ErrorCode {
 	REFUND_ALREADY_PROCESSED(HttpStatus.CONFLICT, "P016", "이미 처리된 반품/환불 요청입니다."),
 	REFUND_INVALID_REASON(HttpStatus.BAD_REQUEST, "P017", "유효하지 않은 반품 사유입니다."),
 	REFUND_NOT_FOUND(HttpStatus.NOT_FOUND, "P018", "환불 정보를 찾을 수 없습니다."),
+	PAYMENT_ALREADY_CANCELLED(HttpStatus.BAD_REQUEST, "P019", "이미 취소된 결제입니다."),
+	PAYMENT_CANCELLATION_FAILED(HttpStatus.BAD_REQUEST, "P020", "주문 취소를 실패했습니다."),
 
 	// Coupon Errors (쿠폰 오류) - K (Koopon)
 	K_COUPON_NOT_FOUND(HttpStatus.NOT_FOUND, "K001", "쿠폰을 찾을 수 없습니다."),


### PR DESCRIPTION

## 관련 이슈
- ref #124 결제 취소

<!-- 예: 
closes #42  
refs #42 
- closes: PR이 머지되면 해당 이슈를 자동으로 닫습니다.
- refs: 해당 이슈를 참고만 하고, 자동으로 닫지 않습니다.
-->

## 작업 내용

 - 결제 취소 api 추가 

-

## 확인 방법

<!--
- 직접 테스트한 방법이나 기능 확인 절차를 설명해주세요.
- 실행 주소(URL), 클릭 순서, 테스트 조건 등이 포함되면 좋습니다.
-->

```
curl --location 'http://127.0.0.1:9012/api/payments/toss/cancel' \
--header 'Content-Type: application/json' \
--data '{
    "orderKey": "orderKey",
    "cancelReason": "그냥 취소"
}'
```


## 브레이킹 체인지 여부

- [ ] 기존 API/기능에 영향이 있습니다 <!-- 예: 필드 이름 변경, 반환값 형식 변경 등 -->
- [x] DB 구조 변경이 포함되어 있습니다. paymentDetail field 추가


## 체크리스트


- [x] 관련 이슈번호를 추가 했나요?
- [x] 리뷰어와 해당하는 레이블을 추가했나요?
- [x] 무엇을 변경했는지 충분히 설명하고 있나요?